### PR TITLE
Fixes for a few memory issues

### DIFF
--- a/Sources/TokamakGTK/GtkContainer+forEach.swift
+++ b/Sources/TokamakGTK/GtkContainer+forEach.swift
@@ -16,33 +16,29 @@
 //
 
 import CGTK
-//import TokamakGTKCHelpers
+import TokamakGTKCHelpers
 
-//extension UnsafeMutablePointer where Pointee == GtkContainer {
-//  /// Iterate over the children
-//  func forEach(
-//    _ closure: @escaping (UnsafeMutablePointer<GtkWidget>?) -> Void
-//  ) {
-//    let closureBox = Unmanaged.passRetained(SingleParamClosureBox(closure)).toOpaque()
-//    let handler: @convention(c) (UnsafeMutablePointer<GtkWidget>?, UnsafeRawPointer) -> Bool = { (ref: UnsafeMutablePointer<GtkWidget>?, data: UnsafeRawPointer) -> Bool in
-//      let unpackedAction = Unmanaged<SingleParamClosureBox<UnsafeMutablePointer<GtkWidget>?, Void>>.fromOpaque(data)
-//      unpackedAction.takeRetainedValue().closure(ref)
-//      return true
-//    }
-//    let cHandler = unsafeBitCast(handler, to: GtkCallback.self)
-//    gtk_container_foreach(self, cHandler, closureBox)
-//  }
-//}
+extension UnsafeMutablePointer where Pointee == GtkContainer {
+  /// Iterate over the children
+  func forEach(
+    _ closure: @escaping (UnsafeMutablePointer<GtkWidget>?) -> Void
+  ) {
+    let closureBox = Unmanaged.passRetained(SingleParamClosureBox(closure)).toOpaque()
+    let handler: @convention(c) (UnsafeMutablePointer<GtkWidget>?, UnsafeRawPointer) -> Bool = { (ref: UnsafeMutablePointer<GtkWidget>?, data: UnsafeRawPointer) -> Bool in
+      let unpackedAction = Unmanaged<SingleParamClosureBox<UnsafeMutablePointer<GtkWidget>?, Void>>.fromOpaque(data)
+      unpackedAction.takeRetainedValue().closure(ref)
+      return true
+    }
+    let cHandler = unsafeBitCast(handler, to: GtkCallback.self)
+    gtk_container_foreach(self, cHandler, closureBox)
+  }
+}
 
-//extension UnsafeMutablePointer where Pointee == GtkWidget {
-//  func isContainer() -> Bool {
-//    let result1 = g_type_check_instance_is_a(self as! UnsafeMutablePointer<GTypeInstance>, gtk_container_get_type ()) == gtk_true()
-//    let result2 =     tokamak_gtk_widget_is_container(self) == gtk_true()
-//
-//    print("SKO", result2, result1)
-//    return result2
-//  }
-//  func isStack() -> Bool {
-//    g_type_check_instance_is_a(self as! UnsafeMutablePointer<GTypeInstance>, gtk_stack_get_type ()) == gtk_true()
-//  }
-//}
+extension UnsafeMutablePointer where Pointee == GtkWidget {
+  func isContainer() -> Bool {
+    tokamak_gtk_widget_is_container(self) == gtk_true()
+  }
+  func isStack() -> Bool {
+    tokamak_gtk_widget_is_stack(self) == gtk_true()
+  }
+}

--- a/Sources/TokamakGTK/GtkContainer+forEach.swift
+++ b/Sources/TokamakGTK/GtkContainer+forEach.swift
@@ -16,29 +16,33 @@
 //
 
 import CGTK
-import TokamakGTKCHelpers
+//import TokamakGTKCHelpers
 
-extension UnsafeMutablePointer where Pointee == GtkContainer {
-  /// Iterate over the children
-  func forEach(
-    _ closure: @escaping (UnsafeMutablePointer<GtkWidget>?) -> Void
-  ) {
-    let closureBox = Unmanaged.passRetained(SingleParamClosureBox(closure)).toOpaque()
-    let handler: @convention(c) (UnsafeMutablePointer<GtkWidget>?, UnsafeRawPointer) -> Bool = { (ref: UnsafeMutablePointer<GtkWidget>?, data: UnsafeRawPointer) -> Bool in
-      let unpackedAction = Unmanaged<SingleParamClosureBox<UnsafeMutablePointer<GtkWidget>?, Void>>.fromOpaque(data)
-      unpackedAction.takeRetainedValue().closure(ref)
-      return true
-    }
-    let cHandler = unsafeBitCast(handler, to: GtkCallback.self)
-    gtk_container_foreach(self, cHandler, closureBox)
-  }
-}
+//extension UnsafeMutablePointer where Pointee == GtkContainer {
+//  /// Iterate over the children
+//  func forEach(
+//    _ closure: @escaping (UnsafeMutablePointer<GtkWidget>?) -> Void
+//  ) {
+//    let closureBox = Unmanaged.passRetained(SingleParamClosureBox(closure)).toOpaque()
+//    let handler: @convention(c) (UnsafeMutablePointer<GtkWidget>?, UnsafeRawPointer) -> Bool = { (ref: UnsafeMutablePointer<GtkWidget>?, data: UnsafeRawPointer) -> Bool in
+//      let unpackedAction = Unmanaged<SingleParamClosureBox<UnsafeMutablePointer<GtkWidget>?, Void>>.fromOpaque(data)
+//      unpackedAction.takeRetainedValue().closure(ref)
+//      return true
+//    }
+//    let cHandler = unsafeBitCast(handler, to: GtkCallback.self)
+//    gtk_container_foreach(self, cHandler, closureBox)
+//  }
+//}
 
-extension UnsafeMutablePointer where Pointee == GtkWidget {
-  func isContainer() -> Bool {
-    tokamak_gtk_widget_is_container(self) == gtk_true()
-  }
-  func isStack() -> Bool {
-    tokamak_gtk_widget_is_stack(self) == gtk_true()
-  }
-}
+//extension UnsafeMutablePointer where Pointee == GtkWidget {
+//  func isContainer() -> Bool {
+//    let result1 = g_type_check_instance_is_a(self as! UnsafeMutablePointer<GTypeInstance>, gtk_container_get_type ()) == gtk_true()
+//    let result2 =     tokamak_gtk_widget_is_container(self) == gtk_true()
+//
+//    print("SKO", result2, result1)
+//    return result2
+//  }
+//  func isStack() -> Bool {
+//    g_type_check_instance_is_a(self as! UnsafeMutablePointer<GTypeInstance>, gtk_stack_get_type ()) == gtk_true()
+//  }
+//}

--- a/Sources/TokamakGTK/Views/Picker.swift
+++ b/Sources/TokamakGTK/Views/Picker.swift
@@ -54,6 +54,9 @@ extension _PickerContainer: AnyWidget {
         if (gtk_combo_box_get_active(plainComboBox) != 0) {
           plainComboBox.withMemoryRebound(to: GtkComboBoxText.self, capacity: 1) { comboBoxText in
             let activeElement = gtk_combo_box_text_get_active_text(comboBoxText)!
+            defer {
+                g_free(activeElement)
+            }
             let element = elements.first {
               guard let text = mapAnyView($0.anyContent, transform: { (view: Text) in view }) else { return false }
               return _TextProxy(text).rawText == String(cString: activeElement)
@@ -61,7 +64,6 @@ extension _PickerContainer: AnyWidget {
             if let selectedValue = element?.anyId as? SelectionValue {
               selection = selectedValue
             }
-            g_free(activeElement)
           }
         }
       }


### PR DESCRIPTION
Always release text in Picker by defer'ing the release as soon as it is created. 
Use 'destroy_data' parameter to release closure boxes in GSignal.swift in order to have the closure boxes be released at the right time.
I'm not certain about my casting and signatures, but it appears to do the trick.
With the releases happening inside the 'handler', I would get a crash after selecting items in the picker after about 10 to 20 tries.